### PR TITLE
Increased autocomplete results to 50

### DIFF
--- a/services/manage/app/services/autocomplete.js
+++ b/services/manage/app/services/autocomplete.js
@@ -47,7 +47,7 @@ export default Service.extend(ObjectQueryManager, {
   async query(type, phrase, { pagination, vars } = {}) {
     const { field, query, resultKey } = this.getQueryFor(type);
     const input = {
-      pagination: pagination || { limit: 20 },
+      pagination: pagination || { limit: 50 },
       field,
       phrase,
       position: 'contains',


### PR DESCRIPTION
Workaround for large number of results  (an issue for common names such as “weekly” and “video”, where there are more than 20 to display)