### PR TITLE
Add delivery data endpoint

### DIFF
--- a/services/delivery/src/routes/data.js
+++ b/services/delivery/src/routes/data.js
@@ -1,0 +1,25 @@
+const { asyncRoute, getAdUnit } = require('../utils');
+const deliver = require('../deliver');
+const db = require('../db');
+
+module.exports = (app) => {
+  app.get('/data/:adunitid', asyncRoute(async (req, res) => {
+    const { params, query } = req;
+    const { adunitid } = params;
+    const adunit = await getAdUnit(adunitid);
+
+    const correlated = await deliver(adunit, query, 'data', req);
+    if (!correlated) return res.status(204).send();
+
+    const [deployment, ad] = await Promise.all([
+      db.findById('deployments', adunit.deploymentId),
+      db.findById('ads', correlated.adId),
+    ]);
+
+    return res.json({
+      deployment,
+      ad,
+      correlated,
+    });
+  }));
+};

--- a/services/delivery/src/routes/index.js
+++ b/services/delivery/src/routes/index.js
@@ -1,7 +1,9 @@
 const click = require('./click');
+const data = require('./data');
 const image = require('./image');
 
 module.exports = (app) => {
   click(app);
+  data(app);
   image(app);
 };


### PR DESCRIPTION
Provides information about the delivered ad (if available) based on the incoming delivery query params. Will _not_ record click or impression events.